### PR TITLE
Update php-cs-fixer ruleset

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -7,13 +7,34 @@ $finder = PhpCsFixer\Finder::create()
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
-        'concat_space' => ['spacing' => 'one'],
+        '@PHPUnit60Migration:risky' => true,
+        'array_indentation' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => true,
-        'pre_increment' => false,
-        'phpdoc_order' => true,
         'blank_line_after_opening_tag' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
+        'increment_style' => ['style' => 'post'],
+        'is_null' => ['use_yoda_style' => false],
+        'list_syntax' => ['syntax' => 'long'],
+        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_chaining_indentation' => true,
+        'modernize_types_casting' => true,
+        'no_multiline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_imports' => true,
         'phpdoc_align' => false,
+        'phpdoc_order' => true,
+        'php_unit_construct' => true,
+        'php_unit_dedicate_assert' => true,
+        'return_assignment' => true,
+        'single_line_comment_style' => true,
+        'ternary_to_null_coalescing' => true,
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+        'void_return' => false,
     ])
     ->setFinder($finder)
-    ->setUsingCache(true);
+    ->setUsingCache(true)
+    ->setRiskyAllowed(true);

--- a/src/Application.php
+++ b/src/Application.php
@@ -95,9 +95,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps a GET request to handler.
-     *
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function get(string $pattern, $handler)
     {
@@ -106,9 +103,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps a POST request to handler.
-     *
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function post(string $pattern, $handler)
     {
@@ -117,9 +111,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps a PUT request to handler.
-     *
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function put(string $pattern, $handler)
     {
@@ -128,9 +119,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps a DELETE request to handler.
-     *
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function delete(string $pattern, $handler)
     {
@@ -139,9 +127,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps a PATCH request to handler.
-     *
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function patch(string $pattern, $handler)
     {
@@ -150,9 +135,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps a OPTIONS request to handler.
-     *
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function options(string $pattern, $handler)
     {
@@ -161,10 +143,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Maps various HTTP requests to handler.
-     *
-     * @param array  $methods
-     * @param string $pattern
-     * @param mixed  $handler
      */
     public function match(array $methods, string $pattern, $handler)
     {

--- a/src/Listener/HttpSession.php
+++ b/src/Listener/HttpSession.php
@@ -24,7 +24,7 @@ class HttpSession
     {
         $request = $event->getRequest();
 
-        if (null === $this->session || $request->hasSession()) {
+        if ($this->session === null || $request->hasSession()) {
             return;
         }
 

--- a/src/Listener/JsonRequestBody.php
+++ b/src/Listener/JsonRequestBody.php
@@ -17,7 +17,7 @@ class JsonRequestBody
     {
         $request = $event->getRequest();
 
-        if (0 !== strpos($request->headers->get('Content-Type', ''), 'application/json')) {
+        if (strpos($request->headers->get('Content-Type', ''), 'application/json') !== 0) {
             return;
         }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsBuilding()
     {
@@ -235,11 +235,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testIsThrowingExceptions()
     {
+        $this->expectException(\Exception::class);
+
         $request = Request::create('/foo/bar', 'GET');
         $expectedResponse = new Response();
         $expectedResponse->setStatusCode(500);

--- a/tests/Listener/HttpSessionTest.php
+++ b/tests/Listener/HttpSessionTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 
-class HttpSessionTest extends \PHPUnit_Framework_TestCase
+class HttpSessionTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsSettingUpSession()
     {

--- a/tests/Listener/JsonRequestBodyTest.php
+++ b/tests/Listener/JsonRequestBodyTest.php
@@ -7,7 +7,7 @@ namespace Linio\Tortilla\Listener;
 use Linio\Tortilla\Event\RequestEvent;
 use Symfony\Component\HttpFoundation\Request;
 
-class JsonRequestBodyTest extends \PHPUnit_Framework_TestCase
+class JsonRequestBodyTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsConvertingJsonBodyToArray()
     {
@@ -41,11 +41,10 @@ class JsonRequestBodyTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($listener->onRequest($event));
     }
 
-    /**
-     * @expectedException \Linio\Exception\BadRequestHttpException
-     */
     public function testIsDetectingBadJson()
     {
+        $this->expectException(\Linio\Exception\BadRequestHttpException::class);
+
         $request = new Request([], [], [], [], [], [], '{"foo" "bar"}');
         $request->headers->set('Content-Type', 'application/json');
         $event = new RequestEvent($request);

--- a/tests/Listener/RequestIdentifierTest.php
+++ b/tests/Listener/RequestIdentifierTest.php
@@ -9,7 +9,7 @@ use Linio\Tortilla\Event\ResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class RequestIdentifierTest extends \PHPUnit_Framework_TestCase
+class RequestIdentifierTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsUsingExistingRequestId()
     {

--- a/tests/Listener/RequestResponseLoggerTest.php
+++ b/tests/Listener/RequestResponseLoggerTest.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class RequestResponseLoggerTest extends \PHPUnit_Framework_TestCase
+class RequestResponseLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsLoggingRequest()
     {

--- a/tests/Log/Formatter/JsonFormatterTest.php
+++ b/tests/Log/Formatter/JsonFormatterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Tortilla\Log\Formatter;
 
-class JsonFormatterTest extends \PHPUnit_Framework_TestCase
+class JsonFormatterTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsAddingTime()
     {

--- a/tests/Route/ControllerResolver/ServiceControllerResolverTest.php
+++ b/tests/Route/ControllerResolver/ServiceControllerResolverTest.php
@@ -6,7 +6,7 @@ namespace Linio\Tortilla\Route\ControllerResolver;
 
 use Pimple\Container;
 
-class ServiceControllerResolverTest extends \PHPUnit_Framework_TestCase
+class ServiceControllerResolverTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsGettingCallableController()
     {
@@ -19,12 +19,11 @@ class ServiceControllerResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedCallable, $callable);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unable to resolve provided controller: foobar
-     */
     public function testIsDetectingInvalidServiceController()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to resolve provided controller: foobar');
+
         $resolver = new ServiceControllerResolver(new Container());
         $resolver->getController('foobar');
     }
@@ -35,12 +34,11 @@ class ServiceControllerResolverTest extends \PHPUnit_Framework_TestCase
         $resolver->setContainer(new Container());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unable to resolve provided controller service: foobar
-     */
     public function testIsDetectingUnregisteredServiceController()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to resolve provided controller service: foobar');
+
         $resolver = new ServiceControllerResolver(new Container());
         $resolver->getController('foobar:indexAction');
     }

--- a/tests/Route/DispatcherTest.php
+++ b/tests/Route/DispatcherTest.php
@@ -8,13 +8,12 @@ use Linio\Tortilla\Route\ControllerResolver\ControllerResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class DispatcherTest extends \PHPUnit_Framework_TestCase
+class DispatcherTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @expectedException \Linio\Exception\NotFoundHttpException
-     */
     public function testIsDetectingNonExistingRoute()
     {
+        $this->expectException(\Linio\Exception\NotFoundHttpException::class);
+
         $request = Request::create('/bar', 'GET');
         $dispatcher = new Dispatcher([
             [
@@ -28,11 +27,10 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher->handle($request);
     }
 
-    /**
-     * @expectedException \Linio\Exception\MethodNotAllowedHttpException
-     */
     public function testIsDetectingMethodNotAllowed()
     {
+        $this->expectException(\Linio\Exception\MethodNotAllowedHttpException::class);
+
         $request = Request::create('/foo', 'POST');
         $dispatcher = new Dispatcher([
             [


### PR DESCRIPTION
This fixes failing tests due to a newer version of php-cs-fixer being used with an older ruleset.